### PR TITLE
Bugfix/#3 カスタムCSSを追加

### DIFF
--- a/MANABIYA_ML_begin/PITCHME.yaml
+++ b/MANABIYA_ML_begin/PITCHME.yaml
@@ -1,0 +1,8 @@
+# カスタムCSSファイル
+theme-override : common_assets/css/PITCHME.css
+
+#スライドのページ数表示の設定
+slide-number: true
+
+#トランジションの設定
+#transition : fade

--- a/common_assets/css/PITCHME.css
+++ b/common_assets/css/PITCHME.css
@@ -1,0 +1,18 @@
+.reveal h1,
+.reveal h2,
+.reveal h3,
+.reveal h4,
+.reveal h5,
+.reveal h6 {
+  text-transform: none;
+  word-wrap: break-word;
+}
+
+.reveal section img {
+  border: 0;
+  box-shadow: none;
+}
+
+.red-char {
+  color: #ff0000;
+}


### PR DESCRIPTION
#3 ヘッダー要素のアルファベットが大文字になる設定を修正する への対応として
カスタムCSSを用いるように設定した。

想定通り設定できているかdevelopにマージして確認する。