### PR TITLE
Bugfix/#4 fragment animation

### DIFF
--- a/MANABIYA_ML_begin/PITCHME.md
+++ b/MANABIYA_ML_begin/PITCHME.md
@@ -26,7 +26,7 @@
 - 新卒2年目 ソフトウェアエンジニア
 - 1月から案件ドリブンで機械学習に従事(レコメンド) |
 - 大学時代、初頭レベルの線形代数、統計はギリギリ修めた。 |
-- <span>[Twitter @ftnext](https://twitter.com/ftnext)、[はてなブログ](http://nikkie-ftnext.hatenablog.com/)>/span> |
+- <span>[Twitter @ftnext](https://twitter.com/ftnext)、[はてなブログ](http://nikkie-ftnext.hatenablog.com/)</span> |
 
 +++
 

--- a/MANABIYA_ML_begin/PITCHME.md
+++ b/MANABIYA_ML_begin/PITCHME.md
@@ -79,7 +79,7 @@
 
 - APIとして公開されている学習済みのAIを使う |
 - 例: Computer Vision API (Microsoft) |
-- <span>自記事で恐縮ですが...[Python入門者でもComputer Vision APIを叩くのは怖くない](https://qiita.com/ftnext/items/970069ff509f69812f23)</span> |
+<span>- 自記事で恐縮ですが...[Python入門者でもComputer Vision APIを叩くのは怖くない](https://qiita.com/ftnext/items/970069ff509f69812f23)</span> |
 
 +++
 


### PR DESCRIPTION
以下の2点が修正されたことを確認するためマージする

https://github.com/ftnext/2018_LTslides/issues/4#issuecomment-374830174
>自己紹介スライド中にspanタグのタイポが表示されている

429c857 にて対応

>「自記事で恐縮ですが...」と「ブラウザでアクセス: 」の箇条書きの・がスライド遷移時から表示されている

87eac75 にて実験