### PR TITLE
Bugfix/#4 箇条書きの・が遷移から表示されてしまう問題は対応しないとする

### DIFF
--- a/MANABIYA_ML_begin/PITCHME.md
+++ b/MANABIYA_ML_begin/PITCHME.md
@@ -79,7 +79,7 @@
 
 - APIとして公開されている学習済みのAIを使う |
 - 例: Computer Vision API (Microsoft) |
-<span>- 自記事で恐縮ですが...[Python入門者でもComputer Vision APIを叩くのは怖くない](https://qiita.com/ftnext/items/970069ff509f69812f23)</span> |
+- <span>自記事で恐縮ですが...[Python入門者でもComputer Vision APIを叩くのは怖くない](https://qiita.com/ftnext/items/970069ff509f69812f23)</span> |
 
 +++
 


### PR DESCRIPTION
Revert "[bugfix] <span>タグ設定部分の箇条書きの・が遷移時から表示されてしまう問題への対処法の実験"
This reverts commit 87eac75fc6246b316d3faaa8c3f5c26d4b8afa30.