### PR TITLE
画像がスライド下部にはみ出さないように設定変更

### DIFF
--- a/MANABIYA_ML_begin/PITCHME.md
+++ b/MANABIYA_ML_begin/PITCHME.md
@@ -58,9 +58,7 @@
 - APIとして公開されている学習済みのAIを使おう |
 - 一から機械学習に取り組まなくてもAさんのやりたいことは達成できる |
 
-+++
-
-![Computer Vision API イメージ](MANABIYA_ML_begin/assets/images/computer-vision-api-image.png)
++++?image=MANABIYA_ML_begin/assets/images/computer-vision-api-image.png
 
 +++
 

--- a/MANABIYA_ML_begin/PITCHME.md
+++ b/MANABIYA_ML_begin/PITCHME.md
@@ -58,7 +58,7 @@
 - APIとして公開されている学習済みのAIを使おう |
 - 一から機械学習に取り組まなくてもAさんのやりたいことは達成できる |
 
-+++?image=MANABIYA_ML_begin/assets/images/computer-vision-api-image.png
++++?image=MANABIYA_ML_begin/assets/images/computer-vision-api-image.png&size=contain
 
 +++
 

--- a/MANABIYA_ML_begin/PITCHME.md
+++ b/MANABIYA_ML_begin/PITCHME.md
@@ -89,11 +89,7 @@
 - アルゴリズムは実装済み。数学の知識がなくても動かせる |
 - コーディング不要。GUIでドラッグ&ドロップ |
 
-+++
-
-### Azure ML Studio利用イメージ
-
-![Azure ML Studioでレコメンド](MANABIYA_ML_begin/assets/images/recommend_sample-7.png)
++++?image=MANABIYA_ML_begin/assets/images/recommend_sample-7.png&size=contain
 
 +++
 
@@ -128,11 +124,7 @@
   - kaggle: データ解析コンペのプラットフォーム |
   - kernel: 参加者が公開しているコンペでのデータ解析の事例 |
 
-+++
-
-### kaggleのkernel
-
-![kaggleのkernel](MANABIYA_ML_begin/assets/images/kaggle-kernel.png)
++++?image=MANABIYA_ML_begin/assets/images/kaggle-kernel.png&size=contain
 
 ---
 

--- a/MANABIYA_ML_begin/PITCHME.md
+++ b/MANABIYA_ML_begin/PITCHME.md
@@ -60,8 +60,6 @@
 
 +++
 
-例: Computer Vision API
-
 ![Computer Vision API イメージ](MANABIYA_ML_begin/assets/images/computer-vision-api-image.png)
 
 +++


### PR DESCRIPTION
インライン挿入画像から背景画像に変更し、size=containを設定した。

GitPitch Wikiを確認したところ、背景画像は大きさを指定できるが、インライン挿入画像は大きさを指定できないという認識。
https://github.com/gitpitch/gitpitch/wiki/Image-Slides